### PR TITLE
Support settings-json generation for system-tests

### DIFF
--- a/.github/actions/packages/prepare-mobile-services-app/action.yml
+++ b/.github/actions/packages/prepare-mobile-services-app/action.yml
@@ -22,6 +22,10 @@ inputs:
   service-key-path:
     description: 'The path to write the service-key to'
     required: false
+  configurations:
+    description: 'Additional mobile services configuration files. Example {"serviceName": "push", "x509": true, "scopes": ["push_all"], "configPath": "./config.json"}'
+    required: false
+    default: '[]'
 outputs:
   service-key:
     description: 'The service-key document as JSON'

--- a/.github/actions/packages/prepare-mobile-services-app/cleanup.js
+++ b/.github/actions/packages/prepare-mobile-services-app/cleanup.js
@@ -14,10 +14,19 @@ async function run() {
         const xsuaaKey =
             core.getInput("broker-xsuaa-key");
         const serviceKeyPath = core.getInput('service-key-path');
+        const configurations = JSON.parse(core.getInput('configurations') || '[]');
 
         if (serviceKeyPath) {
             try {
                 await fs.rm(serviceKeyPath);
+            } catch (e) {
+                //ignore
+            }
+        }
+
+        for (const config of configurations) {
+            try {
+                await fs.rm(config.configPath);
             } catch (e) {
                 //ignore
             }

--- a/.github/actions/packages/prepare-mobile-services-app/client.js
+++ b/.github/actions/packages/prepare-mobile-services-app/client.js
@@ -16,6 +16,21 @@ async function createMobileApplication(config, features) {
     return response;
 }
 
+async function createMobileServicesConfiguration(config, appId, serviceKeyRequest) {
+    const brokerEndpoint = config.brokerEndpoint;
+    const xsuaaConfig = convertXsuaaConfig(config);
+
+    const token = await fetchToken(xsuaaConfig);
+    const response = await got.post(`${brokerEndpoint}/api/broker/v1/apps/${appId}/configurations`, {
+        json: serviceKeyRequest,
+        headers: {
+            'authorization': `bearer ${token}`
+        }
+    }).json();
+
+    return response;
+}
+
 async function deleteMobileApplication(config, appId) {
     const brokerEndpoint = config.brokerEndpoint;
     const xsuaaConfig = convertXsuaaConfig(config);
@@ -84,5 +99,6 @@ async function fetchToken(config) {
 
 module.exports = {
     createMobileApplication: createMobileApplication,
+    createMobileServicesConfiguration: createMobileServicesConfiguration,
     deleteMobileApplication: deleteMobileApplication
 }

--- a/.github/actions/packages/prepare-mobile-services-app/index.js
+++ b/.github/actions/packages/prepare-mobile-services-app/index.js
@@ -16,22 +16,37 @@ async function run() {
         const mobileFeatures = core.getInput("mobile-features");
         const parsedMobileFeatures = mobileFeatures.split(',').filter(f => f.length > 0);
         const serviceKeyPath = core.getInput('service-key-path');
+        const configurations = JSON.parse(core.getInput('configurations') || '[]');
 
-        const mobileAppConfig = await client.createMobileApplication({
+        const clientConfig = {
             brokerEndpoint: brokerEndpoint,
             xsuaaClientId: xsuaaClientId,
             xsuaaUrl: xsuaaUrl,
             xsuaaCert: xsuaaCert,
             xsuaaKey: xsuaaKey
-        }, parsedMobileFeatures);
+        };
 
-        await fs.writeFile('.mobile_app_id', mobileAppConfig['sap.cloud.service'], {
+        const mobileAppConfig = await client.createMobileApplication(clientConfig, parsedMobileFeatures);
+        const appId = mobileAppConfig['sap.cloud.service'];
+        await fs.writeFile('.mobile_app_id', appId, {
             encoding: 'utf-8'
         });
 
         const serviceKeyJsonString = JSON.stringify(mobileAppConfig)
         if (serviceKeyPath) {
             await fs.writeFile(serviceKeyPath, serviceKeyJsonString, {
+                encoding: 'utf-8'
+            });
+        }
+
+        for (const configOption of configurations) {
+            const config = await client.createMobileServicesConfiguration(clientConfig, appId, {
+                serviceName: configOption.serviceName,
+                scopes: configOption.scopes,
+                x509: configOption.x509 === true
+            });
+            const configJsonString = JSON.stringify(config);
+            await fs.writeFile(configOption.configPath, configJsonString, {
                 encoding: 'utf-8'
             });
         }

--- a/validation/mobile-service-broker/README.md
+++ b/validation/mobile-service-broker/README.md
@@ -67,6 +67,24 @@ OpenAPI document can be retrieved with `GET /v3/api-docs`
 
 As response, you'll get the CF service-key.
 
+### Create new Settings File for existing App
+
+```
+POST /api/broker/v1/app/{appId}/configurations
+Content-Type: application/json
+
+{
+    "serviceName": "push",
+    "x509": false,
+    "scopes": [
+      "push_all",
+      "push_single"
+    ]
+}
+```
+to create a new settings file with a `push` service-key for `push_all` and `push_single` scope.  
+See [OpenAPI](#api) for a detailed specification.
+
 ### Delete a Mobile Application
 
 `DELETE /api/broker/v1/apps/{appName}` where `appName` is the application name from the `sap.cloud.service` property.

--- a/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/model/AppConfig.java
+++ b/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/model/AppConfig.java
@@ -1,0 +1,39 @@
+package com.sap.mobile.services.client.validation.broker.model;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Data;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@Builder
+public class AppConfig {
+
+	@JsonProperty("server")
+	private URI server;
+
+	@JsonProperty("platform")
+	private String platform;
+
+	@JsonProperty("applicationId")
+	private String applicationId;
+
+	@JsonProperty("services")
+	private List<AppService> services = new ArrayList<>();
+
+	@Data
+	@Builder
+	public static class AppService {
+		@JsonProperty("name")
+		private String name;
+		@JsonProperty("serviceKeys")
+		private List<Map<?, ?>> serviceKeys = new ArrayList<>();
+	}
+}

--- a/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/model/AppConfigOpenApiModel.java
+++ b/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/model/AppConfigOpenApiModel.java
@@ -1,0 +1,63 @@
+package com.sap.mobile.services.client.validation.broker.model;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+public class AppConfigOpenApiModel {
+
+	@JsonProperty("server")
+	private URI server;
+
+	@JsonProperty("platform")
+	private String platform;
+
+	@JsonProperty("applicationId")
+	private String applicationId;
+
+	@JsonProperty("services")
+	private List<AppService> services = new ArrayList<>();
+
+	@Data
+	public static class AppService {
+		@JsonProperty("name")
+		private String name;
+		@JsonProperty("serviceKeys")
+		private List<AbstractServiceKey> serviceKeys = new ArrayList<>();
+	}
+
+
+	@Data
+	public static abstract class AbstractServiceKey {
+
+		@JsonProperty("alias")
+		private String alias;
+
+		@JsonProperty("url")
+		private URI server;
+
+	}
+
+	@Data
+	@EqualsAndHashCode(callSuper = true)
+	public static class ApiKeyServiceKey extends AbstractServiceKey {
+		@JsonProperty("apiKey")
+		private String apiKey;
+	}
+
+	@Data
+	@EqualsAndHashCode(callSuper = true)
+	public static class X509UaaServiceKey extends AbstractServiceKey {
+		@JsonProperty("uaa")
+		private ServiceKeyOpenApiModel.UaaConfig apiKey;
+	}
+
+}

--- a/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/model/ServiceKeyOpenApiModel.java
+++ b/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/model/ServiceKeyOpenApiModel.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ServiceKey {
+public class ServiceKeyOpenApiModel {
 
 	@JsonProperty("url")
 	private URI url;
@@ -42,6 +42,9 @@ public class ServiceKey {
 
 		@JsonProperty("url")
 		private URI url;
+
+		@JsonProperty("certurl")
+		private URI certUrl;
 
 		@JsonProperty("identityzone")
 		private String identityZone;
@@ -78,5 +81,8 @@ public class ServiceKey {
 
 		@JsonProperty("credential-type")
 		private String credentialType;
+
+		@JsonProperty("certificate")
+		private String certificate;
 	}
 }

--- a/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/model/ServiceKeyRequest.java
+++ b/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/model/ServiceKeyRequest.java
@@ -1,0 +1,22 @@
+package com.sap.mobile.services.client.validation.broker.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+public class ServiceKeyRequest {
+
+	@JsonProperty("serviceName")
+	private String serviceName;
+
+	@JsonProperty("scopes")
+	private Set<String> scopes = new HashSet<>();
+
+	@JsonProperty("x509")
+	private boolean x509;
+
+}

--- a/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/service/PaginationUtils.java
+++ b/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/service/PaginationUtils.java
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import org.cloudfoundry.client.v2.Resource;
 import org.cloudfoundry.client.v3.PaginatedRequest;
 import org.cloudfoundry.client.v3.PaginatedResponse;
 
@@ -36,6 +37,33 @@ public class PaginationUtils {
 				.subscribe(r -> {
 					r.getResources().forEach(emitter::next);
 					if (r.getPagination().getNext() != null) {
+						onNext.run();
+					} else {
+						emitter.complete();
+					}
+				}, emitter::error);
+	}
+
+	public static <R extends org.cloudfoundry.client.v2.PaginatedRequest, T extends Resource<?>, P extends org.cloudfoundry.client.v2.PaginatedResponse<T>> Flux<T> paginateV2(final Function<Integer, R> builder, Function<R, Mono<P>> mapper) {
+		final AtomicInteger page = new AtomicInteger(1);
+		return Flux.create((emitter) -> {
+			final AtomicReference<Runnable> onNext = new AtomicReference<>();
+			onNext.set(() -> {
+				final R request = builder.apply(page.getAndIncrement());
+				addNextV2(request, mapper, emitter, () -> {
+					onNext.get().run();
+				});
+			});
+			onNext.get().run();
+		});
+	}
+
+	private static <R extends org.cloudfoundry.client.v2.PaginatedRequest, T extends Resource<?>, P extends org.cloudfoundry.client.v2.PaginatedResponse<T>> void addNextV2(final R request, final Function<R, Mono<P>> mapper,
+			final FluxSink<T> emitter, final Runnable onNext) {
+		mapper.apply(request)
+				.subscribe(r -> {
+					r.getResources().forEach(emitter::next);
+					if (r.getNextUrl() != null) {
 						onNext.run();
 					} else {
 						emitter.complete();

--- a/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/service/TemplateAwareBrokerService.java
+++ b/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/service/TemplateAwareBrokerService.java
@@ -25,6 +25,8 @@ import com.sap.mobile.services.client.validation.broker.exception.InstanceCreati
 import com.sap.mobile.services.client.validation.broker.exception.InstanceCreationTimeoutException;
 import com.sap.mobile.services.client.validation.broker.exception.MaxConcurrentInstancesReachedException;
 import com.sap.mobile.services.client.validation.broker.exception.NoSuchServiceInstanceException;
+import com.sap.mobile.services.client.validation.broker.model.AppConfig;
+import com.sap.mobile.services.client.validation.broker.model.ServiceKeyRequest;
 import com.sap.mobile.services.client.validation.broker.service.api.BrokerService;
 
 import lombok.RequiredArgsConstructor;
@@ -61,6 +63,11 @@ public class TemplateAwareBrokerService implements BrokerService {
 	@Override
 	public Map<String, ?> getMobileApplicationKey(final String appId) throws NoSuchServiceInstanceException {
 		return delegate.getMobileApplicationKey(appId);
+	}
+
+	@Override
+	public AppConfig createMobileServicesSettingsConfig(final String appId, final ServiceKeyRequest serviceKeyRequest) throws NoSuchServiceInstanceException {
+		return delegate.createMobileServicesSettingsConfig(appId, serviceKeyRequest);
 	}
 
 	private Map<String, ?> createMobileApplication(final BrokerTemplateConfig templateConfig) throws MaxConcurrentInstancesReachedException, InstanceCreationFailedException, InstanceCreationTimeoutException {

--- a/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/service/api/BrokerService.java
+++ b/validation/mobile-service-broker/src/main/java/com/sap/mobile/services/client/validation/broker/service/api/BrokerService.java
@@ -7,12 +7,16 @@ import com.sap.mobile.services.client.validation.broker.exception.InstanceCreati
 import com.sap.mobile.services.client.validation.broker.exception.InstanceCreationTimeoutException;
 import com.sap.mobile.services.client.validation.broker.exception.MaxConcurrentInstancesReachedException;
 import com.sap.mobile.services.client.validation.broker.exception.NoSuchServiceInstanceException;
+import com.sap.mobile.services.client.validation.broker.model.AppConfig;
+import com.sap.mobile.services.client.validation.broker.model.ServiceKeyRequest;
 
 public interface BrokerService {
 
 	Map<String, ?> createMobileApplication(final Set<String> requestFeatures) throws MaxConcurrentInstancesReachedException, InstanceCreationFailedException, InstanceCreationTimeoutException;
 
 	Map<String, ?> getMobileApplicationKey(final String appId) throws NoSuchServiceInstanceException;
+
+	AppConfig createMobileServicesSettingsConfig(final String appId, final ServiceKeyRequest serviceKeyRequest) throws NoSuchServiceInstanceException;
 
 	void deleteMobileApplication(final String appId) throws NoSuchServiceInstanceException;
 


### PR DESCRIPTION
- Enhance mobile-services broker used to provision applications in system-tests to create settings-json files with service-keys (`API-Key` & `x509`)
- Update GH action to generate those files during system-tests