### PR TITLE
Fix PushClient.getNotificationStatus()

### DIFF
--- a/client/src/main/java/com/sap/mobile/services/client/push/Constants.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/Constants.java
@@ -11,7 +11,7 @@ interface Constants {
 		interface V2 {
 			interface Paths {
 				/**
-				 * Root path of mobile services puch backend services v2.
+				 * Root path of mobile services push backend services v2.
 				 */
 				String ROOT_PATH = Constants.ROOT_PATH + "/v2/backend";
 
@@ -39,8 +39,7 @@ interface Constants {
 				String PUSH_TO_CAPABILITY_PATH = Constants.Backend.V2.Paths.ROOT_PATH
 						+ "/capabilities/{capabilityName}/notifications";
 
-				String GET_NOTIFICATION_STATUS = Constants.Backend.V2.Paths.ROOT_PATH
-						+ "/notifications/{notificationId}/status";
+				String GET_NOTIFICATION_STATUS = Constants.Backend.V1.Paths.GET_NOTIFICATION_STATUS;
 
 				String GET_LOCALIZATIONS = Constants.Backend.V2.Paths.ROOT_PATH + "/localizations";
 
@@ -57,5 +56,18 @@ interface Constants {
 				String GET_REGISTRATIONS_GROUP_PARAM = "pushGroup";
 			}
 		}
+
+		interface V1 {
+			interface Paths {
+				/**
+				 * Root path of mobile services puch backend services v2.
+				 */
+				String ROOT_PATH = Constants.ROOT_PATH + "/v1/backend";
+
+				String GET_NOTIFICATION_STATUS = Constants.Backend.V1.Paths.ROOT_PATH
+						+ "/notifications/{notificationId}/status";
+			}
+		}
+
 	}
 }

--- a/client/src/main/java/com/sap/mobile/services/client/push/DTO.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/DTO.java
@@ -342,6 +342,15 @@ class DTONotificationStatus implements NotificationStatus {
 	private Status status;
 	private String caller;
 	private String notificationType;
+	private DTOTopics topics;
+}
+
+@Getter
+@Setter
+@NoArgsConstructor
+class DTOTopics implements Topics{
+	private Integer count;
+	private List<String> value;
 }
 
 @Getter

--- a/client/src/main/java/com/sap/mobile/services/client/push/NotificationStatus.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/NotificationStatus.java
@@ -17,6 +17,9 @@ public interface NotificationStatus {
 	/** The target type, like ios, android ... */
 	String getNotificationType();
 
+	/** List of matching topic subscriptions on {@link PushClient#pushToTopics(java.util.Collection, java.util.Collection, LocalizedPushPayload)} */
+	Topics getTopics();
+
 	/**
 	 * The current notification status.
 	 * <p>

--- a/client/src/main/java/com/sap/mobile/services/client/push/RestTemplatePushClient.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/RestTemplatePushClient.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -141,7 +142,8 @@ class RestTemplatePushClient implements PushClient {
 	@Override
 	public PushResponse pushToTopics(Collection<String> userIds, Collection<String> topics,
 			LocalizedPushPayload pushPayload) {
-		DTOLocalizedPushToTopicPayload payload = new DTOLocalizedPushToTopicPayload(new ArrayList<>(userIds),
+		DTOLocalizedPushToTopicPayload payload = new DTOLocalizedPushToTopicPayload(
+				CollectionUtils.isEmpty(userIds) ? null : new ArrayList<>(userIds),
 				new ArrayList<>(topics), pushPayload);
 		RequestEntity<DTOLocalizedPushToTopicPayload> request = RequestEntity
 				.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_TOPIC_PATH,

--- a/client/src/main/java/com/sap/mobile/services/client/push/Topics.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/Topics.java
@@ -1,0 +1,16 @@
+package com.sap.mobile.services.client.push;
+
+import java.util.List;
+
+/**
+ * List of matching topics response of {@link NotificationStatus}
+ */
+public interface Topics {
+
+    /** Count of matching topics for this notification */
+    Integer getCount();
+
+    /** List of matching topics */
+    List<String> getValue();
+
+}


### PR DESCRIPTION
The push services implements the V1 getNotification status method only. Adding list of matching topics too.
Make PushClient.pustToTopic() more robust, allowing empty filter for userIDs