### PR TITLE
Enforce spring-boot 2 + spring 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "org.springframework:*"
+        versions: [">= 6.x"]
+      - dependency-name: "org.springframework.boot:*"
+        versions: [">= 3.x"]
   - package-ecosystem: npm
     directory: "/.github/actions"
     schedule:


### PR DESCRIPTION
Update `.github/dependabot.yml` and ignore `spring-boot 3.x` and `spring 6.x` as they require Java 17