### PR TITLE
Enforce mockito 4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
         versions: [">= 6.x"]
       - dependency-name: "org.springframework.boot:*"
         versions: [">= 3.x"]
+      - dependency-name: "org.mockito:*"
+        versions: [">= 5.x"]
   - package-ecosystem: npm
     directory: "/.github/actions"
     schedule:


### PR DESCRIPTION
Update `.github/dependabot.yml` and ignore `mockito 5.x` as it requires Java 11