### PR TITLE
Fix concurrency errors in doc release

### DIFF
--- a/.github/workflows/release-documentation.yaml
+++ b/.github/workflows/release-documentation.yaml
@@ -74,6 +74,7 @@ jobs:
   publish-documentation:
     runs-on: ubuntu-latest
     name: Publish Documentation to GH-Pages
+    concurrency: 'publish_docs'
     needs:
       - 'build-documentation'
       - 'build-javadoc'


### PR DESCRIPTION
Add `concurrency: 'publish_docs'` for the `publish-documentation` job in order to prevent merge/rebase issues when multiple jobs are trying to push doc changes at the same time to the `gh-pages` branch