### PR TITLE
Push to Global User ID Support

### DIFF
--- a/client/src/main/java/com/sap/mobile/services/client/push/DTO.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/DTO.java
@@ -236,7 +236,7 @@ class DTOGcmNotification {
 	 * @param duration duration to be formatted
 	 * @return formatted string or null, if param was null.
 	 * @see <a target="_top" href=
-	 * "https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages/#androidconfig">https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages/#androidconfig</a>
+	 *      "https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages/#androidconfig">https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages/#androidconfig</a>
 	 */
 	static String ttlFormat(Duration duration) {
 		if (duration == null) {
@@ -348,7 +348,7 @@ class DTONotificationStatus implements NotificationStatus {
 @Getter
 @Setter
 @NoArgsConstructor
-class DTOTopics implements Topics{
+class DTOTopics implements Topics {
 	private Integer count;
 	private List<String> value;
 }
@@ -509,8 +509,8 @@ class DTOLocalizedPushPayload {
 
 	DTOLocalizedPushPayload(LocalizedPushPayload localizedPushPayload) {
 		this.notification = Utils.safeMap(localizedPushPayload.getNotification(), DTOPushPayload::new);
-		this.notifications =
-				Utils.safeMapMap(localizedPushPayload.getNotifications(), Function.identity(), DTOPushPayload::new);
+		this.notifications = Utils.safeMapMap(localizedPushPayload.getNotifications(), Function.identity(),
+				DTOPushPayload::new);
 	}
 
 	DTOLocalizedPushPayload(PushPayload pushPayload) {
@@ -523,27 +523,32 @@ class DTOLocalizedPushPayload {
 @JsonInclude(Include.NON_NULL)
 class DTOLocalizedPushToUsersPayload {
 	private final List<String> users;
+	private final List<String> userUUIDs;
 	private final DTOLocalizedPushPayload notification;
 
-	DTOLocalizedPushToUsersPayload(List<String> users, LocalizedPushPayload notification) {
+	DTOLocalizedPushToUsersPayload(List<String> users, List<String> userUUIDs, LocalizedPushPayload notification) {
 		this.users = users;
+		this.userUUIDs = userUUIDs;
 		this.notification = new DTOLocalizedPushPayload(notification);
 	}
 }
 
-@Getter @JsonInclude(Include.NON_NULL)
+@Getter
+@JsonInclude(Include.NON_NULL)
 class DTOLocalizedPushToTopicPayload {
-		private final List<String> users;
-		private final List<String> topics;
-		private final DTOLocalizedPushPayload notification;
+	private final List<String> users;
+	private final List<String> userUUIDs;
+	private final List<String> topics;
+	private final DTOLocalizedPushPayload notification;
 
-	DTOLocalizedPushToTopicPayload(List<String> users, List<String> topics,LocalizedPushPayload notification ) {
+	DTOLocalizedPushToTopicPayload(List<String> users, List<String> userUUIDs, List<String> topics,
+			LocalizedPushPayload notification) {
 		this.users = users;
+		this.userUUIDs = userUUIDs;
 		this.topics = topics;
 		this.notification = new DTOLocalizedPushPayload(notification);
-    }
+	}
 }
-
 
 @Getter
 @JsonInclude(Include.NON_NULL)
@@ -566,8 +571,8 @@ class DTOLocalizedPushToCapabilitiesPayload {
 	DTOLocalizedPushToCapabilitiesPayload(LocalizedPushToCapabilitiesPayload localizedPushToCapabilitiesPayload) {
 		this.users = Utils.safeMapCollection(localizedPushToCapabilitiesPayload.getUsers(), DTOCapabilityUser::new,
 				Collectors.toSet());
-		this.notification =
-				Utils.safeMap(localizedPushToCapabilitiesPayload.getNotification(), DTOLocalizedPushPayload::new);
+		this.notification = Utils.safeMap(localizedPushToCapabilitiesPayload.getNotification(),
+				DTOLocalizedPushPayload::new);
 	}
 }
 
@@ -575,10 +580,12 @@ class DTOLocalizedPushToCapabilitiesPayload {
 @JsonInclude(Include.NON_NULL)
 class DTOLocalizedUserNotification {
 	private final String user;
+	private final String userUUID;
 	private final DTOLocalizedPushPayload notification;
 
 	DTOLocalizedUserNotification(LocalizedUserNotification userNotification) {
 		this.user = userNotification.getUser();
+		this.userUUID = userNotification.getUserUUID();
 		this.notification = Utils.safeMap(userNotification.getNotification(), DTOLocalizedPushPayload::new);
 	}
 }

--- a/client/src/main/java/com/sap/mobile/services/client/push/LocalizedUserNotification.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/LocalizedUserNotification.java
@@ -21,6 +21,8 @@ public interface LocalizedUserNotification {
 
 	String getUser();
 
+	String getUserUUID();
+
 	LocalizedPushPayload getNotification();
 
 	/**
@@ -30,6 +32,7 @@ public interface LocalizedUserNotification {
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	final class Builder {
 		private String user;
+		private String userUUID;
 		private LocalizedPushPayload notification;
 
 		/**
@@ -39,7 +42,17 @@ public interface LocalizedUserNotification {
 		 * @return
 		 */
 		public Builder user(String user) {
-			return new Builder(user, this.notification);
+			return new Builder(user, this.userUUID, this.notification);
+		}
+
+		/**
+		 * Specifies the global user ID
+		 * 
+		 * @param userUUID
+		 * @return
+		 */
+		public Builder userUUID(String userUUID) {
+			return new Builder(this.user, userUUID, this.notification);
 		}
 
 		/**
@@ -49,7 +62,7 @@ public interface LocalizedUserNotification {
 		 * @return
 		 */
 		public Builder notification(LocalizedPushPayload notification) {
-			return new Builder(this.user, notification);
+			return new Builder(this.user, this.userUUID, notification);
 		}
 
 		/**
@@ -58,13 +71,14 @@ public interface LocalizedUserNotification {
 		 * @return
 		 */
 		public LocalizedUserNotification build() {
-			return new LocalizedUserNotificationObject(this.user, this.notification);
+			return new LocalizedUserNotificationObject(this.user, this.userUUID, this.notification);
 		}
 
 		@Getter
 		@RequiredArgsConstructor
 		private static class LocalizedUserNotificationObject implements LocalizedUserNotification {
 			private final String user;
+			private final String userUUID;
 			private final LocalizedPushPayload notification;
 		}
 	}

--- a/client/src/main/java/com/sap/mobile/services/client/push/PushClient.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/PushClient.java
@@ -74,6 +74,19 @@ public interface PushClient {
 	PushResponse pushToUsers(Collection<String> userIds, LocalizedPushPayload pushPayload) throws ClientException;
 
 	/**
+	 * Triggers a notification to a defined set of users, identified by their
+	 * userId or global user ID. If a single user has multiple
+	 * devices registered, all devices will receive the notification.
+	 *
+	 * @param userIds     userIds
+	 * @param userUUIDs   userUUIDs
+	 * @param pushPayload payload
+	 * @return response
+	 */
+	PushResponse pushToUsers(Collection<String> userIds, Collection<String> userUUIDs, LocalizedPushPayload pushPayload)
+			throws ClientException;
+
+	/**
 	 * Triggers a notification to a group with the same payload for all recipients.
 	 *
 	 * @param group       group
@@ -142,6 +155,19 @@ public interface PushClient {
 	 * @return
 	 */
 	PushResponse pushToTopics(Collection<String> userIds, Collection<String> topics, LocalizedPushPayload pushPayload);
+
+	/**
+	 * Triggers notifications to devices that have an active subscription for any
+	 * of the given topic
+	 * 
+	 * @param userIds     optional filter on userIds
+	 * @param userUUIDs   optional filter on global user IDs
+	 * @param topics      List of topics
+	 * @param pushPayload payload
+	 * @return
+	 */
+	PushResponse pushToTopics(Collection<String> userIds, Collection<String> userUUIDs, Collection<String> topics,
+			LocalizedPushPayload pushPayload);
 
 	/**
 	 * Retrieve the notification status by its ID.

--- a/client/src/main/java/com/sap/mobile/services/client/push/RestTemplatePushClient.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/RestTemplatePushClient.java
@@ -55,17 +55,17 @@ class RestTemplatePushClient implements PushClient {
 	@Override
 	public PushResponse pushToApplication(LocalizedPushPayload pushPayload) throws ClientException {
 		DTOLocalizedPushPayload payload = new DTOLocalizedPushPayload(pushPayload);
-		RequestEntity<DTOLocalizedPushPayload> request =
-				RequestEntity.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_APPLICATION_PATH,
-								this.basicPathVariables().build())
-						.body(payload);
+		RequestEntity<DTOLocalizedPushPayload> request = RequestEntity
+				.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_APPLICATION_PATH,
+						this.basicPathVariables().build())
+				.body(payload);
 		ResponseEntity<DTOPushResponse> response = this.restTemplate.exchange(request, DTOPushResponse.class);
 		return response.getBody();
 	}
 
 	@Override
-	public PushResponse pushToDevice(final String userId, final String deviceId, final PushPayload pushPayload) throws
-			ClientException {
+	public PushResponse pushToDevice(final String userId, final String deviceId, final PushPayload pushPayload)
+			throws ClientException {
 		return pushToDevice(userId, deviceId, LocalizedPushPayload.builder().notification(pushPayload).build());
 	}
 
@@ -73,31 +73,39 @@ class RestTemplatePushClient implements PushClient {
 	public PushResponse pushToDevice(String userId, String deviceId, LocalizedPushPayload pushPayload)
 			throws ClientException {
 		DTOLocalizedPushPayload payload = new DTOLocalizedPushPayload(pushPayload);
-		RequestEntity<DTOLocalizedPushPayload> request =
-				RequestEntity.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_USER_PATH,
-								this.basicPathVariables().put("userId", userId).putAndBuild("deviceId", deviceId))
-						.body(payload);
+		RequestEntity<DTOLocalizedPushPayload> request = RequestEntity
+				.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_USER_PATH,
+						this.basicPathVariables().put("userId", userId).putAndBuild("deviceId", deviceId))
+				.body(payload);
 		ResponseEntity<DTOPushResponse> response = this.restTemplate.exchange(request, DTOPushResponse.class);
 		return response.getBody();
 	}
 
 	@Override
-	public PushResponse pushToUsers(final Collection<String> userIds, final PushPayload pushPayload) throws
-			ClientException {
+	public PushResponse pushToUsers(final Collection<String> userIds, final PushPayload pushPayload)
+			throws ClientException {
 		return pushToUsers(userIds, LocalizedPushPayload.builder().notification(pushPayload).build());
+	}
+
+	@Override
+	public PushResponse pushToUsers(Collection<String> userIds, Collection<String> userUUIDs,
+			LocalizedPushPayload pushPayload) throws ClientException {
+		DTOLocalizedPushToUsersPayload payload = new DTOLocalizedPushToUsersPayload(
+				CollectionUtils.isEmpty(userIds) ? null : new ArrayList<>(userIds),
+				CollectionUtils.isEmpty(userUUIDs) ? null : new ArrayList<>(userUUIDs),
+				pushPayload);
+		RequestEntity<DTOLocalizedPushToUsersPayload> request = RequestEntity
+				.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_USERS_PATH,
+						this.basicPathVariables().build())
+				.body(payload);
+		ResponseEntity<DTOPushResponse> response = this.restTemplate.exchange(request, DTOPushResponse.class);
+		return response.getBody();
 	}
 
 	@Override
 	public PushResponse pushToUsers(Collection<String> userIds, LocalizedPushPayload pushPayload)
 			throws ClientException {
-		DTOLocalizedPushToUsersPayload payload =
-				new DTOLocalizedPushToUsersPayload(new ArrayList<>(userIds), pushPayload);
-		RequestEntity<DTOLocalizedPushToUsersPayload> request =
-				RequestEntity.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_USERS_PATH,
-								this.basicPathVariables().build())
-						.body(payload);
-		ResponseEntity<DTOPushResponse> response = this.restTemplate.exchange(request, DTOPushResponse.class);
-		return response.getBody();
+		return pushToUsers(userIds, null , pushPayload);
 	}
 
 	@Override
@@ -108,20 +116,19 @@ class RestTemplatePushClient implements PushClient {
 	@Override
 	public PushResponse pushToGroup(String group, LocalizedPushPayload pushPayload) throws ClientException {
 		DTOLocalizedPushPayload payload = new DTOLocalizedPushPayload(pushPayload);
-		RequestEntity<DTOLocalizedPushPayload> request =
-				RequestEntity.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_GROUP_PATH,
-								this.basicPathVariables().putAndBuild("group", group))
-						.body(payload);
+		RequestEntity<DTOLocalizedPushPayload> request = RequestEntity
+				.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_GROUP_PATH,
+						this.basicPathVariables().putAndBuild("group", group))
+				.body(payload);
 		ResponseEntity<DTOPushResponse> response = this.restTemplate.exchange(request, DTOPushResponse.class);
 		return response.getBody();
 	}
 
 	@Override
 	public PushResponse pushToCapability(final String capability,
-			final PushToCapabilitiesPayload pushToCapabilitiesPayload) throws
-			ClientException {
+			final PushToCapabilitiesPayload pushToCapabilitiesPayload) throws ClientException {
 		return pushToCapability(capability, LocalizedPushToCapabilitiesPayload.builder().notification(
-						LocalizedPushPayload.builder().notification(pushToCapabilitiesPayload.getNotification()).build())
+				LocalizedPushPayload.builder().notification(pushToCapabilitiesPayload.getNotification()).build())
 				.users(pushToCapabilitiesPayload.getCapabilityUsers())
 				.build());
 	}
@@ -129,28 +136,35 @@ class RestTemplatePushClient implements PushClient {
 	@Override
 	public PushResponse pushToCapability(String capability,
 			LocalizedPushToCapabilitiesPayload pushToCapabilitiesPayload) throws ClientException {
-		DTOLocalizedPushToCapabilitiesPayload payload =
-				new DTOLocalizedPushToCapabilitiesPayload(pushToCapabilitiesPayload);
-		RequestEntity<DTOLocalizedPushToCapabilitiesPayload> request =
-				RequestEntity.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_CAPABILITY_PATH,
-								this.basicPathVariables().putAndBuild("capabilityName", capability))
-						.body(payload);
+		DTOLocalizedPushToCapabilitiesPayload payload = new DTOLocalizedPushToCapabilitiesPayload(
+				pushToCapabilitiesPayload);
+		RequestEntity<DTOLocalizedPushToCapabilitiesPayload> request = RequestEntity
+				.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_CAPABILITY_PATH,
+						this.basicPathVariables().putAndBuild("capabilityName", capability))
+				.body(payload);
 		ResponseEntity<DTOPushResponse> response = this.restTemplate.exchange(request, DTOPushResponse.class);
 		return response.getBody();
+	}
+	
+	@Override
+	public PushResponse pushToTopics(Collection<String> userIds, Collection<String> userUUIDs,
+			Collection<String> topics, LocalizedPushPayload pushPayload) {
+				DTOLocalizedPushToTopicPayload payload = new DTOLocalizedPushToTopicPayload(
+						CollectionUtils.isEmpty(userIds) ? null : new ArrayList<>(userIds),
+						CollectionUtils.isEmpty(userUUIDs) ? null : new ArrayList<>(userUUIDs),
+						new ArrayList<>(topics), pushPayload);
+				RequestEntity<DTOLocalizedPushToTopicPayload> request = RequestEntity
+						.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_TOPIC_PATH,
+								this.basicPathVariables().build())
+						.body(payload);
+				ResponseEntity<DTOPushResponse> response = this.restTemplate.exchange(request, DTOPushResponse.class);
+				return response.getBody();
 	}
 
 	@Override
 	public PushResponse pushToTopics(Collection<String> userIds, Collection<String> topics,
 			LocalizedPushPayload pushPayload) {
-		DTOLocalizedPushToTopicPayload payload = new DTOLocalizedPushToTopicPayload(
-				CollectionUtils.isEmpty(userIds) ? null : new ArrayList<>(userIds),
-				new ArrayList<>(topics), pushPayload);
-		RequestEntity<DTOLocalizedPushToTopicPayload> request = RequestEntity
-				.method(HttpMethod.POST, Constants.Backend.V2.Paths.PUSH_TO_TOPIC_PATH,
-						this.basicPathVariables().build())
-				.body(payload);
-		ResponseEntity<DTOPushResponse> response = this.restTemplate.exchange(request, DTOPushResponse.class);
-		return response.getBody();
+		return pushToTopics(userIds, null, topics, pushPayload);
 	}
 
 	@Override
@@ -166,22 +180,22 @@ class RestTemplatePushClient implements PushClient {
 	public PushResponse bulkPush(LocalizedPushPayload rootNotification,
 			Collection<LocalizedUserNotification> userNotifications) {
 		DTOLocalizedBulkPush payload = new DTOLocalizedBulkPush(rootNotification, userNotifications);
-		RequestEntity<DTOLocalizedBulkPush> request =
-				RequestEntity.method(HttpMethod.POST, Constants.Backend.V2.Paths.BULK_PUSH_PATH,
-								this.basicPathVariables().build())
-						.body(payload);
+		RequestEntity<DTOLocalizedBulkPush> request = RequestEntity
+				.method(HttpMethod.POST, Constants.Backend.V2.Paths.BULK_PUSH_PATH,
+						this.basicPathVariables().build())
+				.body(payload);
 		ResponseEntity<DTOPushResponse> response = this.restTemplate.exchange(request, DTOPushResponse.class);
 		return response.getBody();
 	}
 
 	@Override
 	public NotificationStatusResponse getNotificationStatus(final String notificationId) {
-		RequestEntity<Void> request =
-				RequestEntity.method(HttpMethod.GET, Constants.Backend.V2.Paths.GET_NOTIFICATION_STATUS,
-								this.basicPathVariables().putAndBuild("notificationId", notificationId))
-						.build();
-		ResponseEntity<DTONotificationStatusResponse> response =
-				this.restTemplate.exchange(request, DTONotificationStatusResponse.class);
+		RequestEntity<Void> request = RequestEntity
+				.method(HttpMethod.GET, Constants.Backend.V2.Paths.GET_NOTIFICATION_STATUS,
+						this.basicPathVariables().putAndBuild("notificationId", notificationId))
+				.build();
+		ResponseEntity<DTONotificationStatusResponse> response = this.restTemplate.exchange(request,
+				DTONotificationStatusResponse.class);
 		return response.getBody();
 	}
 
@@ -190,7 +204,8 @@ class RestTemplatePushClient implements PushClient {
 		RequestEntity<Void> request = RequestEntity.method(HttpMethod.GET,
 				UriComponentsBuilder.fromPath(Constants.Backend.V2.Paths.GET_LOCALIZATIONS)
 						.queryParam(Constants.Backend.V2.Params.GET_LOCALIZATIONS_USER_PARAM, userIds)
-						.build(this.basicPathVariables().build()).toString()).build();
+						.build(this.basicPathVariables().build()).toString())
+				.build();
 		ParameterizedTypeReference<Set<String>> type = new ParameterizedTypeReference<Set<String>>() {
 		};
 		ResponseEntity<Set<String>> response = this.restTemplate.exchange(request, type);
@@ -199,24 +214,23 @@ class RestTemplatePushClient implements PushClient {
 
 	@Override
 	public List<? extends PushRegistration> getRegistrations(Optional<String> usernameOpt, Optional<String> groupOpt) {
-		UriComponentsBuilder uriComponentsBuilder =
-				UriComponentsBuilder.fromPath(Constants.Backend.V2.Paths.GET_REGISTRATIONS);
+		UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder
+				.fromPath(Constants.Backend.V2.Paths.GET_REGISTRATIONS);
 		if (usernameOpt.isPresent()) {
-			uriComponentsBuilder =
-					uriComponentsBuilder.queryParam(Constants.Backend.V2.Params.GET_REGISTRATIONS_USERNAME_PARAM,
-							usernameOpt.get());
+			uriComponentsBuilder = uriComponentsBuilder.queryParam(
+					Constants.Backend.V2.Params.GET_REGISTRATIONS_USERNAME_PARAM,
+					usernameOpt.get());
 		}
 		if (groupOpt.isPresent()) {
-			uriComponentsBuilder =
-					uriComponentsBuilder.queryParam(Constants.Backend.V2.Params.GET_REGISTRATIONS_GROUP_PARAM,
-							groupOpt.get());
+			uriComponentsBuilder = uriComponentsBuilder.queryParam(
+					Constants.Backend.V2.Params.GET_REGISTRATIONS_GROUP_PARAM,
+					groupOpt.get());
 		}
 
 		RequestEntity<Void> request = RequestEntity.method(HttpMethod.GET,
 				uriComponentsBuilder.build(this.basicPathVariables().build()).toString()).build();
-		ParameterizedTypeReference<List<DTOPushRegistration>> type =
-				new ParameterizedTypeReference<List<DTOPushRegistration>>() {
-				};
+		ParameterizedTypeReference<List<DTOPushRegistration>> type = new ParameterizedTypeReference<List<DTOPushRegistration>>() {
+		};
 		ResponseEntity<List<DTOPushRegistration>> response = this.restTemplate.exchange(request, type);
 		return response.getBody();
 	}
@@ -225,7 +239,8 @@ class RestTemplatePushClient implements PushClient {
 	public Optional<PushRegistration> getRegistration(String registrationId) {
 		RequestEntity<Void> request = RequestEntity.method(HttpMethod.GET,
 				UriComponentsBuilder.fromPath(Constants.Backend.V2.Paths.GET_REGISTRATION)
-						.build(this.basicPathVariables().putAndBuild("registrationId", registrationId))).build();
+						.build(this.basicPathVariables().putAndBuild("registrationId", registrationId)))
+				.build();
 		ResponseEntity<DTOPushRegistration> response = this.restTemplate.exchange(request, DTOPushRegistration.class);
 		if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
 			return Optional.empty();

--- a/client/src/test/java/com/sap/mobile/services/client/push/PushClientMockedTest.java
+++ b/client/src/test/java/com/sap/mobile/services/client/push/PushClientMockedTest.java
@@ -124,22 +124,6 @@ public class PushClientMockedTest {
 		MatcherAssert.assertThat(mockPushServer, MockPushServer.hasBeenVerified());
 	}
 
-	@Test
-	public void testPushToUsersWithEmptyList() throws Exception {
-		mockPushServer.expectPushToUsers()
-				.withJsonBodyFromResource("payloads/request-push-to-users-empty-list.json")
-				.andRespond().withInvalidPushUserListSizeError();
-
-		assertThrows(Exception.class, () -> {
-			//TODO: enhance error handling
-			testee.pushToUsers(Collections.emptyList(), PushPayload.builder()
-					.alert("Hello World")
-					.build());
-		});
-
-		MatcherAssert.assertThat(mockPushServer, MockPushServer.hasBeenVerified());
-	}
-
 	@Test(expected = NoMessageSentException.class)
 	public void testPushToUsersNoSuchRegistration() throws Exception {
 		mockPushServer.expectPushToUsers()


### PR DESCRIPTION
BTP Mobile Services Push Service supports the Global User ID to specify the recipients in the following V2 push methods:
- Push to User
- Push to Topic
- Bulk Push