### PR TITLE
Add Missing getNotificationId and providerReference in NotificationSt…

### DIFF
--- a/client/src/main/java/com/sap/mobile/services/client/push/DTO.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/DTO.java
@@ -344,6 +344,7 @@ class DTONotificationStatus implements NotificationStatus {
 	private String notificationType;
 	private DTOTopics topics;
 	private String notificationId;
+	private String providerReference;
 }
 
 @Getter

--- a/client/src/main/java/com/sap/mobile/services/client/push/NotificationStatus.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/NotificationStatus.java
@@ -26,10 +26,15 @@ public interface NotificationStatus {
 	Topics getTopics();
 
 	/**
+	 * Notification ID
+	 */
+	String getNotificationId();
+
+	/**
 	 * Native notification ID from channel, like APNs or FCM.
 	 * APNs apns-unique-id is used on development target.
 	 */
-	String getNotificationId();
+	String getProviderReference();
 
 	/**
 	 * The current notification status.


### PR DESCRIPTION
…atus

The fields are missing in the Notification Status response. The property providerReference is preset since 2402.