### PR TITLE
Enhancement: Support APNs Interruption-Level

### DIFF
--- a/client/src/main/java/com/sap/mobile/services/client/push/ApnsNotification.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/ApnsNotification.java
@@ -67,6 +67,8 @@ public interface ApnsNotification {
 
 	Boolean getMutableContent();
 
+	InterruptionLevel getInterruptionLevel();
+
 	/**
 	 * APNS specific notification properties. See
 	 * 
@@ -101,6 +103,7 @@ public interface ApnsNotification {
 		private List<String> urlArguments;
 		private String threadId;
 		private Boolean mutableContent;
+		private InterruptionLevel interruptionLevel;
 
 		/**
 		 * expire notification at given timestamp
@@ -112,7 +115,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -127,7 +130,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -140,7 +143,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -157,7 +160,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -170,7 +173,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -185,7 +188,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -199,7 +202,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -213,7 +216,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -229,7 +232,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -243,7 +246,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -256,7 +259,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -272,7 +275,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -286,7 +289,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -299,7 +302,7 @@ public interface ApnsNotification {
 					localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -315,7 +318,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -330,7 +333,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -343,7 +346,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -357,7 +360,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -370,7 +373,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -384,7 +387,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -398,7 +401,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -412,7 +415,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -425,7 +428,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		/**
@@ -439,7 +442,21 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					mutableContent);
+					mutableContent, this.interruptionLevel);
+		}
+
+		/**
+		 * The interruption-level is optional and defines the importance and delivery
+		 * timing of a notification
+		 */
+		public Builder interruptionLevel(InterruptionLevel interruptionLevel) {
+			return new Builder(this.expiration, this.category, this.contentAvailable, this.pushType, this.customValues,
+					this.sound, this.customSound, this.topic, this.alertBody, this.localizedAlertKey,
+					this.localizedAlertArguments, this.alertTitle, this.localizedAlertTitleKey,
+					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
+					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
+					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
+					this.mutableContent, interruptionLevel);
 		}
 
 		public ApnsNotification build() {
@@ -450,7 +467,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent);
+					this.mutableContent, this.interruptionLevel);
 		}
 
 		@Getter
@@ -480,6 +497,7 @@ public interface ApnsNotification {
 			private final List<String> urlArguments;
 			private final String threadId;
 			private final Boolean mutableContent;
+			private final InterruptionLevel interruptionLevel;
 		}
 	}
 }

--- a/client/src/main/java/com/sap/mobile/services/client/push/ApnsNotification.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/ApnsNotification.java
@@ -69,6 +69,10 @@ public interface ApnsNotification {
 
 	InterruptionLevel getInterruptionLevel();
 
+	String getTargetContentId();
+
+	Float getRelevanceScore();
+
 	/**
 	 * APNS specific notification properties. See
 	 * 
@@ -104,6 +108,8 @@ public interface ApnsNotification {
 		private String threadId;
 		private Boolean mutableContent;
 		private InterruptionLevel interruptionLevel;
+		private String targetContentId;
+		private Float relevanceScore;
 
 		/**
 		 * expire notification at given timestamp
@@ -115,7 +121,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -130,7 +136,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -143,7 +149,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -160,7 +166,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -173,7 +179,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -188,7 +194,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -202,7 +208,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -216,7 +222,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -232,7 +238,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -246,7 +252,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -259,7 +265,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -275,7 +281,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -289,7 +295,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -302,7 +308,7 @@ public interface ApnsNotification {
 					localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -318,7 +324,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -333,7 +339,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -346,7 +352,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -360,7 +366,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -373,7 +379,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -387,7 +393,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -401,7 +407,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -415,7 +421,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -428,7 +434,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -442,7 +448,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					mutableContent, this.interruptionLevel);
+					mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		/**
@@ -456,7 +462,36 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, interruptionLevel);
+					this.mutableContent, interruptionLevel, this.targetContentId, this.relevanceScore);
+		}
+
+		/**
+		 * The identifier of the window brought forward. The value of this key will be
+		 * populated on the UNNotificationContent object created from the push payload.
+		 */
+		public Builder targetContentId(String targetContentId) {
+			return new Builder(this.expiration, this.category, this.contentAvailable, this.pushType, this.customValues,
+					this.sound, this.customSound, this.topic, this.alertBody, this.localizedAlertKey,
+					this.localizedAlertArguments, this.alertTitle, this.localizedAlertTitleKey,
+					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
+					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
+					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
+					this.mutableContent, this.interruptionLevel, targetContentId, this.relevanceScore);
+		}
+
+		/**
+		 * The relevance score, a number between 0 and 1, that the system uses to sort
+		 * the notifications from your app. The highest score gets featured in the
+		 * notification summary.
+		 */
+		public Builder relevanceScore(Float relevanceScore) {
+			return new Builder(this.expiration, this.category, this.contentAvailable, this.pushType, this.customValues,
+					this.sound, this.customSound, this.topic, this.alertBody, this.localizedAlertKey,
+					this.localizedAlertArguments, this.alertTitle, this.localizedAlertTitleKey,
+					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
+					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
+					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
+					this.mutableContent, this.interruptionLevel, this.targetContentId, relevanceScore);
 		}
 
 		public ApnsNotification build() {
@@ -467,7 +502,7 @@ public interface ApnsNotification {
 					this.localizedAlertTitleArguments, this.alertSubtitle, this.localizedAlertSubtitleKey,
 					this.localizedAlertSubtitleArguments, this.launchImageFileName, this.showActionButton,
 					this.actionButtonLabel, this.localizedActionButtonKey, this.urlArguments, this.threadId,
-					this.mutableContent, this.interruptionLevel);
+					this.mutableContent, this.interruptionLevel, this.targetContentId, this.relevanceScore);
 		}
 
 		@Getter
@@ -498,6 +533,8 @@ public interface ApnsNotification {
 			private final String threadId;
 			private final Boolean mutableContent;
 			private final InterruptionLevel interruptionLevel;
+			private final String targetContentId;
+			private final Float relevanceScore;
 		}
 	}
 }

--- a/client/src/main/java/com/sap/mobile/services/client/push/DTO.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/DTO.java
@@ -69,6 +69,9 @@ class DTOApnsNotification {
 	private final String threadId;
 	private final Boolean mutableContent;
 	private final String interruptionLevel;
+	private final String targetContentId;
+	private final Float relevanceScore;
+
 
 	DTOApnsNotification(ApnsNotification apnsNotification) {
 		this.expiration = apnsNotification.getExpiration();
@@ -96,6 +99,9 @@ class DTOApnsNotification {
 		this.threadId = apnsNotification.getThreadId();
 		this.mutableContent = apnsNotification.getMutableContent();
 		this.interruptionLevel = apnsNotification.getInterruptionLevel() != null ? apnsNotification.getInterruptionLevel().toString() : null;
+		this.targetContentId = apnsNotification.getTargetContentId();
+		this.relevanceScore = apnsNotification.getRelevanceScore();
+
 	}
 }
 

--- a/client/src/main/java/com/sap/mobile/services/client/push/DTO.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/DTO.java
@@ -68,6 +68,7 @@ class DTOApnsNotification {
 	private final List<String> urlArguments;
 	private final String threadId;
 	private final Boolean mutableContent;
+	private final String interruptionLevel;
 
 	DTOApnsNotification(ApnsNotification apnsNotification) {
 		this.expiration = apnsNotification.getExpiration();
@@ -94,6 +95,7 @@ class DTOApnsNotification {
 		this.urlArguments = apnsNotification.getUrlArguments();
 		this.threadId = apnsNotification.getThreadId();
 		this.mutableContent = apnsNotification.getMutableContent();
+		this.interruptionLevel = apnsNotification.getInterruptionLevel() != null ? apnsNotification.getInterruptionLevel().toString() : null;
 	}
 }
 

--- a/client/src/main/java/com/sap/mobile/services/client/push/InterruptionLevel.java
+++ b/client/src/main/java/com/sap/mobile/services/client/push/InterruptionLevel.java
@@ -1,0 +1,19 @@
+package com.sap.mobile.services.client.push;
+
+public enum InterruptionLevel {
+    PASSIVE("passive"),
+    ACTIVE("active"),
+    TIME_SENSITIVE("time-sensitive"),
+    CRITICAL("critical");
+
+    private String level;
+
+    private InterruptionLevel(String level) {
+        this.level = level;
+    }
+
+    public String toString() {
+        return this.level;
+    }
+
+}

--- a/client/src/test/java/com/sap/mobile/services/client/push/DTOTest.java
+++ b/client/src/test/java/com/sap/mobile/services/client/push/DTOTest.java
@@ -27,4 +27,18 @@ public class DTOTest {
 				DTOGetNotificationStatusResponse.class);
 		Assert.assertNotNull(response.getStatusDetails().getCaller());
 	}
+
+	@Test
+	public void testDTOApnsNotificationInterruptionLevel() throws Exception {
+		ApnsNotification apnsNotification = ApnsNotification.builder().interruptionLevel(InterruptionLevel.CRITICAL).build();
+		DTOApnsNotification dtoApnsNotification = new DTOApnsNotification(apnsNotification);
+		Assert.assertEquals("critical", dtoApnsNotification.getInterruptionLevel());
+	}
+
+	@Test
+	public void testDTOApnsNotificationInterruptionLevelNull() throws Exception {
+		ApnsNotification apnsNotification = ApnsNotification.builder().build();
+		DTOApnsNotification dtoApnsNotification = new DTOApnsNotification(apnsNotification);
+		Assert.assertNull(dtoApnsNotification.getInterruptionLevel());
+	}
 }

--- a/client/src/test/java/com/sap/mobile/services/client/push/DTOTest.java
+++ b/client/src/test/java/com/sap/mobile/services/client/push/DTOTest.java
@@ -30,7 +30,8 @@ public class DTOTest {
 
 	@Test
 	public void testDTOApnsNotificationInterruptionLevel() throws Exception {
-		ApnsNotification apnsNotification = ApnsNotification.builder().interruptionLevel(InterruptionLevel.CRITICAL).build();
+		ApnsNotification apnsNotification = ApnsNotification.builder().interruptionLevel(InterruptionLevel.CRITICAL)
+				.build();
 		DTOApnsNotification dtoApnsNotification = new DTOApnsNotification(apnsNotification);
 		Assert.assertEquals("critical", dtoApnsNotification.getInterruptionLevel());
 	}
@@ -40,5 +41,33 @@ public class DTOTest {
 		ApnsNotification apnsNotification = ApnsNotification.builder().build();
 		DTOApnsNotification dtoApnsNotification = new DTOApnsNotification(apnsNotification);
 		Assert.assertNull(dtoApnsNotification.getInterruptionLevel());
+	}
+
+	@Test
+	public void testDTOApnsNotificationRelevanceScoreWhenSetNotNull() {
+		ApnsNotification apnsNotification = ApnsNotification.builder().relevanceScore(1.0F).build();
+		DTOApnsNotification dtoApnsNotification = new DTOApnsNotification(apnsNotification);
+		Assert.assertEquals(1.0F, dtoApnsNotification.getRelevanceScore().floatValue(), 0.01F);
+	}
+
+	@Test
+	public void testDTOApnsNotificationRelevanceScoreWhenNotSetExpectNull() {
+		ApnsNotification apnsNotification = ApnsNotification.builder().build();
+		DTOApnsNotification dtoApnsNotification = new DTOApnsNotification(apnsNotification);
+		Assert.assertNull(dtoApnsNotification.getRelevanceScore());
+	}
+
+	@Test
+	public void testDTOApnsNotificationTargetContentIdWhenSetTargetContentIdIsNotNull() {
+		ApnsNotification apnsNotification = ApnsNotification.builder().targetContentId("some value").build();
+		DTOApnsNotification dtoApnsNotification = new DTOApnsNotification(apnsNotification);
+		Assert.assertEquals("some value", dtoApnsNotification.getTargetContentId());
+	}
+
+	@Test
+	public void testDTOApnsNotificationTargetContentIdWhenNotSetExpectNull() {
+		ApnsNotification apnsNotification = ApnsNotification.builder().build();
+		DTOApnsNotification dtoApnsNotification = new DTOApnsNotification(apnsNotification);
+		Assert.assertNull(dtoApnsNotification.getTargetContentId());
 	}
 }


### PR DESCRIPTION
The interruption-level defines the he importance and delivery timing of a notification. This property is a notification configuration and could not be set by the extra-parameters.

This resolves #453 and requires Mobile Services 2406.