### PR TITLE
Fixing API Doc Build Result Path

### DIFF
--- a/.github/workflows/release-documentation.yaml
+++ b/.github/workflows/release-documentation.yaml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: javadoc-build
-          path: client/target/site/apidocs/**
+          path: client/target/reports/apidocs/**
   publish-documentation:
     runs-on: ubuntu-latest
     name: Publish Documentation to GH-Pages


### PR DESCRIPTION
The java docs are generated now in target/reports/apidocs